### PR TITLE
[2월 5주차 알고리즘 스터디] 스택, 큐 / 이주희

### DIFF
--- a/juhee/src/inf/stackandqueue/Q01.java
+++ b/juhee/src/inf/stackandqueue/Q01.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.util.Stack;
 
 public class Q01 {
+    // Big-O: O(N)
     public static void main(String[] args) throws IOException {
         BufferedReader stdIn = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter stdOut = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/juhee/src/inf/stackandqueue/Q02.java
+++ b/juhee/src/inf/stackandqueue/Q02.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.util.Stack;
 
 public class Q02 {
+//    Big-O Notation: O(N)
     public static void main(String[] args) throws IOException {
         BufferedReader stdIn = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter stdOut = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/juhee/src/inf/stackandqueue/Q03.java
+++ b/juhee/src/inf/stackandqueue/Q03.java
@@ -6,6 +6,7 @@ import java.util.Stack;
 import java.util.StringTokenizer;
 
 public class Q03 {
+    // Big-O: O(n^2)
     public static void main(String[] args) throws IOException {
         BufferedReader stdIn = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter stdOut = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/juhee/src/inf/stackandqueue/Q04.java
+++ b/juhee/src/inf/stackandqueue/Q04.java
@@ -7,6 +7,7 @@ import java.util.Stack;
  * 후위식 연산(postfix)
  */
 public class Q04 {
+    // Big-O: O(N)
     public static void main(String[] args) throws IOException {
         BufferedReader stdIn = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter stdOut = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/juhee/src/inf/stackandqueue/Q05.java
+++ b/juhee/src/inf/stackandqueue/Q05.java
@@ -17,11 +17,10 @@ public class Q05 {
         int cnt = 0;
         for (int i = 1; i < input.length; i++) {
             if (input[i] == ')') {
+                stack.pop();
                 if (input[i - 1] == input[i]) {
-                    stack.pop();
                     cnt++;
                 } else {
-                    stack.pop();
                     cnt += stack.size();
                 }
             } else {

--- a/juhee/src/inf/stackandqueue/Q05.java
+++ b/juhee/src/inf/stackandqueue/Q05.java
@@ -7,6 +7,7 @@ import java.util.Stack;
  * 쇠막대기
  */
 public class Q05 {
+    // Big-O: O(N)
     public static void main(String[] args) throws IOException {
         BufferedReader stdIn = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter stdOut = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/juhee/src/inf/stackandqueue/Q06.java
+++ b/juhee/src/inf/stackandqueue/Q06.java
@@ -9,6 +9,7 @@ import java.util.StringTokenizer;
  * 공주 구하기
  */
 public class Q06 {
+    // Big-O: O(N)
     public static void main(String[] args) throws IOException {
         BufferedReader stdIn = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter stdOut = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/juhee/src/inf/stackandqueue/Q07.java
+++ b/juhee/src/inf/stackandqueue/Q07.java
@@ -1,0 +1,34 @@
+package inf.stackandqueue;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * 교육과정 설계
+ */
+public class Q07 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader stdIn = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter stdOut = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        String mc = stdIn.readLine();
+        Queue<Character> queue = new LinkedList<>();
+        String answer = "YES";
+        for (int i = 0; i < mc.length(); i++) queue.offer(mc.charAt(i));
+        char[] cc = stdIn.readLine().toCharArray();
+        for (int i = 0; i < cc.length; i++) {
+            if (mc.contains(String.valueOf(cc[i]))) {
+                if (queue.peek() != cc[i]) {
+                    answer = "NO";
+                    break;
+                }
+                queue.poll();
+            }
+        }
+        if (!queue.isEmpty()) answer = "NO";
+        stdOut.write(answer);
+        stdOut.flush();
+        stdOut.close();
+        stdIn.close();
+    }
+}


### PR DESCRIPTION
### ⭐ 해당 이슈(스터디) 번호

#7 

### 📘 문제 설명 : 쇠파이프 🤘

#### 🔖 문제 요약

주어진 괄호 표현에서 레이저와 쇠막대기의 배치를 고려하여 쇠막대기가 잘려진 총 개수를 구하는 문제입니다. 
괄호 표현에서 괄호 쌍 '()'는 레이저를 나타내며, 쇠막대기의 왼쪽 끝은 여는 괄호 '('로, 오른쪽 끝은 닫힌 괄호 ')'로 표현됩니다. 쇠막대기는 레이저에 의해 잘려지며, 쇠막대기와 레이저의 배치에 따라 잘려진 쇠막대기의 총 개수를 계산합니다.

#### 💻 입출력 양식

입력:
- 괄호로 이루어진 문자열이 입력으로 들어옵니다.

출력:
- 잘려진 조각의 총 개수를 출력

### 🤔 문제의 엣지 케이스 (선택 사항)

엣지케이스는 크게 없습니다. 레이저는 어떤 쇠막대기의 양 끝과도 겹치지 않고, 적어도 하나는 존재하기 때문이지요.

### 🗑️ 사용한 데이터 구조와 알고리즘

사용한 데이터 구조: 스택
알고리즘: 해당 사항 없음

### ✨ 접근 방법 및 풀이 방법

문자열에 대하여 loop를 idx = 1부터 시작합니다. (n과 n - 1 idx의 값을 비교하기 때문)
인덱스에 해당하는 요소에 대하여 분기 처리를 진행합니다.

이때 스택의 크기는 겹쳐진 파이프의 수라고 생각하시면 됩니다.

만약 현재 문자가 ')'일 경우 괄호가 닫혀야 하기 때문에 stack에서 하나를 꺼냅니다. (pop)
1) 여기서 전 문자가 ')'일 경우 위에 파이프가 끝나는 지점인 것을 의미합니다. 파이프의 끝점이기 때문에 총 파이프의 개수에 하나를 더해줍니다.

2) 여기서 전 문자가 '('일 경우 레이저가 발생한 것을 의미합니다. 
레이저 발사...!!
![te-laser00](https://github.com/algorithms-are-fun-perhaps/algorithms-are-fun-perhaps/assets/89906414/ce87040b-acb8-4de9-b748-dfb43fefae04)
레이저가 발사될 경우 쌓여있는 파이프의 수 만큼 조각의 개수가 증가하기 때문에 stack.size()만큼 cnt를 증가시킵니다.

만약 '('일 경우에는 파이프가 쌓이는 것을 의미하기에  해당 값을 스택에 저장해두면 됩니다. 

### 📢 토의사항
문제는 어떠셨나요? 저는 쇠파이프 문제가 제일 버거웠답니다.

### 📘 문제 설명: 공주 구하기 👸 

#### 🔖 문제 요약

정보 왕국의 왕자들은 시계 방향으로 동그랗게 앉고, 번호를 순서대로 외칩니다. 
각 왕자가 특정 숫자를 외치면 공주 구출에서 제외되고 나가게 됩니다. 
이러한 과정을 거쳐 마지막까지 남은 왕자가 공주를 구하러 갈 수 있습니다.
라는 구시대적인 시나리오의 문제입니다.

#### 💻 입출력 양식

입력:
- 첫 줄에 왕자의 수 N과 외치는 특정 번호인 K가 주어집니다.

출력:
- 구출하러 간다는 왕자의 번호를 한줄에 출력하면 됩니다.

### 🤔 문제의 엣지 케이스 (선택 사항)
엣지케이스는 없습니다.

### 🗑️ 사용한 데이터 구조와 알고리즘
사용한 데이터 구조: Queue (LinkedList)
사용한 알고리즘: 해당 사항 없음

### ✨ 접근 방법 및 풀이 방법
모든 왕자(머저리)들을 넣은 뒤 while문을 사용하여 한명의 왕자(머저리)가 남을 때 까지 반복문을 돌려줍니다. 
매 반복문마다 번호를 외치기 때문에 cnt를 증가시켜줍니다 그리고 해당 왕자를 poll해줍니다.
만약 해당 cnt가 k와 같을 경우 해주어 큐에서 제외시키고 cnt를 0으로 초기화합니다.
만약 cnt가 k보다 작을 경우 poll 한 왕자를 다시 큐의 맨 마지막으로 push해줍니다.

### 📢 토의사항
큐의 개념을 사용할 수 있는 문제였습니다.

### 🗒️이론 정리 링크

금주는 일정상의 문제로 이론정리는 생략하였습니다...!
